### PR TITLE
Vehicle jump bar/player locator bar obstructing status bars fix

### DIFF
--- a/Experience Remover/build.gradle.kts
+++ b/Experience Remover/build.gradle.kts
@@ -18,6 +18,9 @@ val javaVersion = libs.versions.java.map { it.toInt() }
 base.archivesName = archivesBaseName
 version = modVersion.get()
 group = mavenGroup.get()
+loom {
+    accessWidenerPath = file("src/main/resources/experience_remover.classtweaker")
+}
 repositories {
     maven("https://maven.wispforest.io")
     maven("https://maven.kosmx.dev/")

--- a/Experience Remover/src/main/java/com/smushytaco/experience_remover/mixins/client/LowerStatusBars.java
+++ b/Experience Remover/src/main/java/com/smushytaco/experience_remover/mixins/client/LowerStatusBars.java
@@ -6,6 +6,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -14,24 +15,52 @@ public abstract class LowerStatusBars {
     @Final
     @Shadow
     private Minecraft minecraft;
+
+    @Shadow
+    protected abstract Gui.ContextualInfo nextContextualInfoState();
+
+    @Unique
+    private boolean isModEnabled() {
+        return !ExperienceRemover.INSTANCE.getConfig().getDisableMod();
+    }
+
+    @Unique
+    private static final int shift = 6;
+
+    @Unique
+    private boolean shouldMoveStatusBars() {
+        Gui.ContextualInfo contextualInfo = nextContextualInfoState();
+        return isModEnabled() && contextualInfo == Gui.ContextualInfo.EMPTY;
+    }
+
+    @Unique
+    private void lowerStatusBars(GuiGraphics context) {
+        if (shouldMoveStatusBars()) {
+            ((WindowAccessor) (Object) minecraft.getWindow()).setGuiScaledHeight(context.guiHeight() + shift);
+        }
+    }
+
+    @Unique
+    private void raiseStatusBars(GuiGraphics context) {
+        if (shouldMoveStatusBars()) {
+            ((WindowAccessor) (Object) minecraft.getWindow()).setGuiScaledHeight(context.guiHeight() - shift);
+        }
+    }
+
     @Inject(method = "renderPlayerHealth", at = @At("HEAD"))
     private void hookHeadRenderStatusBars(GuiGraphics context, CallbackInfo ci) {
-        if (ExperienceRemover.INSTANCE.getConfig().getDisableMod()) return;
-        ((WindowAccessor) (Object) minecraft.getWindow()).setGuiScaledHeight(context.guiHeight() + 6);
+        lowerStatusBars(context);
     }
     @Inject(method = "renderPlayerHealth", at = @At("RETURN"))
     private void hookReturnRenderStatusBars(GuiGraphics context, CallbackInfo ci) {
-        if (ExperienceRemover.INSTANCE.getConfig().getDisableMod()) return;
-        ((WindowAccessor) (Object) minecraft.getWindow()).setGuiScaledHeight(context.guiHeight() - 6);
+        raiseStatusBars(context);
     }
     @Inject(method = "renderVehicleHealth", at = @At("HEAD"))
     private void hookHeadRenderMountHealth(GuiGraphics context, CallbackInfo ci) {
-        if (ExperienceRemover.INSTANCE.getConfig().getDisableMod()) return;
-        ((WindowAccessor) (Object) minecraft.getWindow()).setGuiScaledHeight(context.guiHeight() + 6);
+        lowerStatusBars(context);
     }
     @Inject(method = "renderVehicleHealth", at = @At("RETURN"))
     private void hookReturnRenderMountHealth(GuiGraphics context, CallbackInfo ci) {
-        if (ExperienceRemover.INSTANCE.getConfig().getDisableMod()) return;
-        ((WindowAccessor) (Object) minecraft.getWindow()).setGuiScaledHeight(context.guiHeight() - 6);
+        raiseStatusBars(context);
     }
 }

--- a/Experience Remover/src/main/resources/experience_remover.classtweaker
+++ b/Experience Remover/src/main/resources/experience_remover.classtweaker
@@ -1,0 +1,3 @@
+classTweaker v1 named
+
+accessible class net/minecraft/client/gui/Gui$ContextualInfo

--- a/Experience Remover/src/main/resources/fabric.mod.json
+++ b/Experience Remover/src/main/resources/fabric.mod.json
@@ -33,5 +33,6 @@
     "minecraft": ">=${minecraft}",
     "java": ">=${java}",
     "owo": ">=${owo_version}"
-  }
+  },
+  "accessWidener" : "experience_remover.classtweaker"
 }


### PR DESCRIPTION
When a vehicle jump bar (horse jump bar, camel dash bar) or a player locator bar shows up, things like health and armor bar are properly moved upwards.
Also contains some refactoring to make the code in `LowerStatusBars` class cleaner (better readability, eliminated repetition) :).